### PR TITLE
Changed name of query dump

### DIFF
--- a/pydbtools/get_athena_query_response.py
+++ b/pydbtools/get_athena_query_response.py
@@ -33,7 +33,7 @@ def get_athena_query_response(
     """
 
     # Get role specific path for athena output
-    bucket = "alpha-athena-query-dump"
+    bucket = "mojap-athena-query-dump"
     rn = "eu-west-1"
 
     if force_ec2:


### PR DESCRIPTION
This changes the S3 bucket used for temporarily storing the results of Athena queries. 

This is linked to https://github.com/moj-analytical-services/data-engineering-infra/issues/14

Tested manually, but doesn't pass unit tests because of existing issue with boolean columns and missing values. To solve separately.