### PR TITLE
Fix df to temp permissions

### DIFF
--- a/pydbtools/__init__.py
+++ b/pydbtools/__init__.py
@@ -28,4 +28,4 @@ from ._sql_render import (  # noqa: F401
     render_sql_template,
 )
 
-__version__ = "5.2.1"
+__version__ = "5.2.2"

--- a/pydbtools/_wrangler.py
+++ b/pydbtools/_wrangler.py
@@ -538,9 +538,9 @@ def dataframe_to_temp_table(df: pd.DataFrame, table: str, boto3_session=None) ->
     wr.catalog.delete_table_if_exists(
         database=db, table=table, boto3_session=boto3_session
     )
-    ## Write table
-    # Include timestamp in path to avoid permissions problems with
-    # previous sessions
+    # Write table
+    # - Include timestamp in path to avoid permissions problems with
+    #   previous sessions
     ts = str(time.time()).replace(".", "")
     path = s3_path_join(table_dir, f"{ts}/{table}.parquet")
     wr.s3.to_parquet(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "pydbtools"
-version = "5.2.1"
+version = "5.2.2"
 description = "A python package to query data via amazon athena and bring it into a pandas df using aws-wrangler."
 license = "MIT"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]


### PR DESCRIPTION
Fixes a problem where data for a temporary table from a previous session that had yet to be auto-deleted could not be deleted to make way for a table refresh.