### PR TITLE
Update awswrangler dependency to one that supports create_ctas_table

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1772,4 +1772,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11" # wrangler dependency
-content-hash = "e3ce55ca4e9f815c08801716529b8ff414fed76eba2f1e46770191dcb7a727c4"
+content-hash = "204efd142e8c99f06b8dd57a020b726a75d04e909f041f4ab21ba86a69658648"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 python = ">=3.8,<3.11" # wrangler dependency
 boto3 = ">=1.7.4"
 sqlparse = "^0.4.4"
-awswrangler = "^2.12.0"
+awswrangler = "^2.15.0"
 pyarrow = ">=5.0.0"
 Jinja2 = ">=3.1.0"
 sql-metadata = "^2.3.0"


### PR DESCRIPTION
We're wrapping `create_ctas_table` which was only introduced in awswrangler v2.15.0. Updating the poetry dependencies to reflect this.