### PR TITLE
Feature delete table only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.5.7 - 2023-05-25
+
+- Functions that delete tables only, see `pydbtools.delete_table`.
+
+## v5.5.6 - 2023-05-05
+
+- Reverted to the working version for Analytical Platform
+
+## v5.5.5 - 2023-05-02
+
+- Fixes region issue with new SSO method by getting region from bucket.
+
+## v5.5.4 - 2023-04-26
+
+- Fixes user_id parsing in preparation for SSO, which changes the userid to an email address.
+
 ## v5.5.3 - 2023-03-06
 
 - Fixed issue in create_temp_table

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ pydb.delete_database('my_database')
 pydb.delete_table_and_data(database='__temp__', table='my_temp_table')
 ```
 
+### Delete table but keep data on S3
+
+```python
+import pydbtools as pydb
+
+pydb.delete_table(database='my_database', table='my_table')
+
+# These can be used for temporary databases and tables.
+pydb.delete_table(database='__temp__', table='my_temp_table')
+```
+
+
 For more details see [the notebook on deletions](examples/delete_databases_tables_and_partitions.ipynb).
 
 ## Usage / Examples

--- a/pydbtools/__init__.py
+++ b/pydbtools/__init__.py
@@ -18,6 +18,7 @@ from ._wrangler import (  # noqa: F401
     read_sql_queries_gen,
     delete_partitions_and_data,
     delete_table_and_data,
+    delete_table_if_exists,
     delete_temp_table,
     delete_database_and_data,
     save_query_to_parquet,

--- a/pydbtools/__init__.py
+++ b/pydbtools/__init__.py
@@ -18,7 +18,7 @@ from ._wrangler import (  # noqa: F401
     read_sql_queries_gen,
     delete_partitions_and_data,
     delete_table_and_data,
-    delete_table_if_exists,
+    delete_table,
     delete_temp_table,
     delete_database_and_data,
     save_query_to_parquet,

--- a/pydbtools/_wrangler.py
+++ b/pydbtools/_wrangler.py
@@ -483,7 +483,7 @@ def delete_table_and_data(table: str, database: str, boto3_session=None):
 
 
 @init_athena_params(allow_boto3_session=True)
-def delete_table_if_exists(table: str, database: str, boto3_session=None):
+def delete_table(table: str, database: str, boto3_session=None):
     """
     Deletes a table from an Athena database.
 

--- a/pydbtools/_wrangler.py
+++ b/pydbtools/_wrangler.py
@@ -483,6 +483,29 @@ def delete_table_and_data(table: str, database: str, boto3_session=None):
 
 
 @init_athena_params(allow_boto3_session=True)
+def delete_table_if_exists(table: str, database: str, boto3_session=None):
+    """
+    Deletes a table from an Athena database.
+
+    Args:
+        table (str): The table name to drop.
+        database (str): The database name.
+
+    Returns:
+        True if table exists and is deleted, False if table
+        does not exist
+    """
+
+    if table in list(tables(database=database, limit=None)["Table"]):
+        wr.catalog.delete_table_if_exists(
+            database=database, table=table, boto3_session=boto3_session
+        )
+        return True
+    else:
+        return False
+
+
+@init_athena_params(allow_boto3_session=True)
 def delete_temp_table(table: str, boto3_session=None):
     """
     Deletes a temporary table.


### PR DESCRIPTION
New function feature to mimic [awswrangler.catalog.delete_table_if_exists](https://aws-sdk-pandas.readthedocs.io/en/stable/stubs/awswrangler.catalog.delete_table_if_exists.html) - so we can delete the table only but keep the S3 data (similar to an SQL query of `DROP TABLE IF EXISTS [TABLE_NAME]`).

``` python
def delete_table(table: str, database: str, boto3_session=None):
    """
    Deletes a table from an Athena database.

    Args:
        table (str): The table name to drop.
        database (str): The database name.

    Returns:
        True if table exists and is deleted, False if table
        does not exist
    """

    if table in list(tables(database=database, limit=None)["Table"]):
        wr.catalog.delete_table_if_exists(
            database=database, table=table, boto3_session=boto3_session
        )
        return True
    else:
        return False

```

Have updated the README.md and CHANGELOG.md too.
