### PR TITLE
Allow Generic GH Action to use pydb tools

### DIFF
--- a/pydbtools/utils.py
+++ b/pydbtools/utils.py
@@ -60,7 +60,7 @@ aws_role_regex_rules = [
         None,
     ),
     (
-        r"[A-Za-z0-9]+:GitHubActions", # GitHub action for e2e
+        r"[A-Za-z0-9]+:GitHubActions",  # GitHub action for e2e
         None,
     ),
 ]

--- a/pydbtools/utils.py
+++ b/pydbtools/utils.py
@@ -59,6 +59,10 @@ aws_role_regex_rules = [
         r"^[0-9]+$",  # numeric
         None,
     ),
+    (
+        r"[A-Za-z0-9]+:GitHubActions", # GitHub action for e2e
+        None,
+    ),
 ]
 
 


### PR DESCRIPTION
The e2e tests in create a pipeline were breaking since the user name `ABCDEF12345:GitHubActions` wasn't an accepted user name in pydbtools. So fixing that here.