### PR TITLE
Update the actions versions used in the publish workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install the project
         run: uv build --no-sources
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist
 
@@ -32,9 +32,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: artifact/
+          packages-dir: artifact/


### PR DESCRIPTION
Both download-artifact and upload-artifact were out of date, with upload-artifact v3 also no longer available.